### PR TITLE
Fix cached artifacts and utilize $DOKKU_TRACE

### DIFF
--- a/bin/steps/build_with_cargo
+++ b/bin/steps/build_with_cargo
@@ -7,4 +7,5 @@ status "Building application using Cargo"
 cd "$build_dir"
 # To debug git issues:
 #export RUST_LOG="cargo::sources::git=debug"
-HOME="$cargo_home" cargo build --verbose --release | indent
+[[ $DOKKU_TRACE ]] && VERBOSE="--verbose" || VERBOSE=""
+HOME="$cargo_home" cargo build $VERBOSE --release | indent

--- a/bin/steps/cache_build_artifacts
+++ b/bin/steps/cache_build_artifacts
@@ -1,3 +1,3 @@
 status "Caching build artifacts"
 [[ -d "$cache_dir/app-cache" ]] && rm -r $cache_dir/app-cache
-cp -r target $cache_dir/app-cache
+cp -rp target $cache_dir/app-cache

--- a/bin/steps/init
+++ b/bin/steps/init
@@ -1,6 +1,6 @@
-set -e              # fail fast
-set -o pipefail     # dont ignore errors when piping
-# set -x            # enable debugging
+set -e                        # fail fast
+set -o pipefail               # dont ignore errors when piping
+[[ $DOKKU_TRACE ]] && set -x  # enable debugging
 
 build_dir=$1
 cache_dir=$2

--- a/bin/steps/use_cached_build_artifacts
+++ b/bin/steps/use_cached_build_artifacts
@@ -1,5 +1,5 @@
 if [ -d "$cache_dir/app-cache" ]; then
   status "Using cached build artifacts to speedup incremental build"
   [[ -d "$build_dir/target" ]] && rm -r $build_dir/target
-  cp -r $cache_dir/app-cache $build_dir/target
+  cp -pr $cache_dir/app-cache $build_dir/target
 fi


### PR DESCRIPTION
It's important to pass `-p` (preserve file attributes) to `cp` for the cached artifacts to work properly! Otherwise file timestamps are changed, the cache looks more recent than the source files and no build is triggered. 

Also I utilize `$DOKKU_TRACE` to configure `set -x` and the `--verbose` flag for `rustc`.
